### PR TITLE
Various improvements to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,13 @@ tag_build = .dev
 
 [bdist_wheel]
 #universal = 1 # commented out, as the library is not tested on python 3.*
+
+# Note: The package maintainer needs sphinx and sphinx-pypi-upload to build and
+# upload the documentation to the Python Package Index (PyPI)
+[build_sphinx]
+source-dir = docs/source
+build-dir  = docs/build
+all_files  = 1
+
+[upload_sphinx]
+upload-dir = docs/build/html

--- a/setup.py
+++ b/setup.py
@@ -3,31 +3,50 @@ import sys, os
 
 version = '0.9.9'
 
+# Set common test dependencies
+test_dependencies = [
+    'mock',
+    'nose',
+]
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+if sys.version_info < (2, 7):
+    test_dependencies.append('argparse')
+    test_dependencies.append('unittest2')
+
+# Note: The package maintainer needs pypandoc and pygments to properly convert
+# the Markdown-formatted README into RestructuredText before uploading to PyPi
+# See https://bitbucket.org/pypa/pypi/issues/148/support-markdown-for-readmes
+try:
+    import pypandoc
+    long_description=pypandoc.convert('README.md', 'rst')
+except(IOError, ImportError):
+    long_description=open('README.md').read()
 
 setup(name='b2handle',
       version=version,
-      long_description=read('README.md'),
       description=('Library for management of handles '
                    'in the EUDAT project.'),
-      classifiers=['Development Status :: 4 - Beta'],
+      long_description=long_description,
+      classifiers=[
+          'Development Status :: 4 - Beta',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Intended Audience :: Developers',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+      ],
       keywords=['handles', 'PIDs'],
       author='EUDAT project, subtask 5.3.3',
       author_email='buurman@dkrz.de',
       url='http://eudat-b2safe.github.io/B2HANDLE',
       download_url='https://github.com/EUDAT-B2SAFE/B2HANDLE',
-      packages=['b2handle','tests'],
+      packages=['b2handle', 'b2handle/tests'],
       zip_safe=False,
       install_requires=[
           'requests',
-          'logging',
           'uuid',
           'datetime',
-          'mock',
-          'unittest2', # only for py 2.6?
-          'unittest',
-          'argparse'
-      ]
+      ],
+      tests_require=test_dependencies,
+      test_suite="nose.collector",
 )


### PR DESCRIPTION
Improvements include:
- Fix `packages` definition
- Move test dependencies to `tests_require`
- Conditionally import dependencies for Python 2.6
- Add more classifiers

As noted in `setup.py`, the package maintainer needs [pypandoc](https://github.com/bebraw/pypandoc) and [pygments](http://pygments.org/) to properly convert the Markdown-formatted README into RestructuredText before uploading to PyPI. This is a known limitation of PyPI - see:
- https://bitbucket.org/pypa/pypi/issues/148/support-markdown-for-readmes
- http://stackoverflow.com/a/23265673

Support has also been added for building and uploading Sphinx docs (see updated `setup.cfg`):

```
python setup.py build_sphinx
python setup.py upload_sphinx
```
